### PR TITLE
📦 Bump pypi:scikit-learn:0.24.0 from 0.24.0 to 1.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 numpy==1.21.0
-scikit-learn==0.24.0
+scikit-learn==1.5.0


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2024-5206 | Medium  | A sensitive data leakage vulnerability was identified in scikit-learn's<br>TfidfVectorizer, specifically in versions up to and including 1.4.1.post1, which<br>was fixed in version 1.5.0. The vulnerability arises from the unexpected storage<br>of all tokens present in the training data within the `stop_words_` attribute,<br>rather than only storing the subset of tokens required for the TF-IDF technique<br>to function. This behavior leads to the potential leakage of sensitive<br>information, as the `stop_words_` attribute could contain tokens that were meant<br>to be discarded and not stored, such as passwords or keys. The impact of this<br>vulnerability varies based on the nature of the data being processed by the<br>vectorizer. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
